### PR TITLE
Sửa lỗi màn hình, khung bị giật khi chơi game

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -88,7 +88,7 @@ int main() {
     srand((int)time(0));
     Qua.x = rand() % (MAXX - MINX) + MINX;
     Qua.y = rand() % (MAXY - MINY) + MINY;
-
+    VeKhung();               //đặt hàm vẽ khung ra ngoài vòng lặp While(1), chỉ vẽ khung 1 lần duy nhất.
     while (1) {
         if (kbhit()) {
             t = getch();
@@ -107,10 +107,16 @@ int main() {
             }
         }
 
-        system("cls");
-        r.Ve(Qua);
-        r.DiChuyen(Huong, Qua);
-        VeKhung();
+        for (int i = 0; i < r.DoDai; i++)           // xóa rắn bằng cách thay thế thành ký tự khoảng trắng " " 
+        {
+            gotoxy(r.A[i].x, r.A[i].y);
+            cout << " "; 
+        }
+        
+        r.DiChuyen(Huong, Qua);                       //đổi thử tự chạy hàm, cho hàm di chuyển chạy trước, vẽ chạy sau.
+        r.Ve(Qua);                                 // nếu để hàm vẽ chạy trước, sau khi xóa thân rắn, hàm vẽ nó lại vẽ lại toàn bộ những thứ đã xóa (giá trị cũ) . rồi hàm di chuyển tịnh tiến toàn bộ, nên con rắn đi để lại cái đuôi kéo dài.  
+        
+        
 
         if (RanDungTuong(r.A[0])) {
             gotoxy(10, MAXY + 2);


### PR DESCRIPTION
Không sử dụng hàm xóa toàn bộ màn hình systems("cls") Đưa hàm VeKhung() ra ngoài vòng lặp While(1) <=> chỉ vẽ khung 1 lần duy nhất. Xóa rắn bằng cách : dùng vòng lặp for duyệt hết con rắn, thay thế bằng kỹ tự khoảng trắng. Sau đó vẽ lại rắn. LƯU Ý: đổi thứ tự chạy hàm Dichuyen chạy trước hàm Ve. đọc comment và suy luận để hiểu.

Chỉ xóa những thành phần di chuyển (con rắn), sau đó vẽ lại con rắn.